### PR TITLE
Fix csv export email issue

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -36,8 +36,8 @@ class ResultsController < ApplicationController
 
   def export
     to_email  = params[:to_email].presence || Rails.application.secrets.notification_email
-    from_date = params[:from_date]
-    to_date   = params[:to_date]
+    from_date = params[:from_date].to_s
+    to_date   = params[:to_date].to_s
 
     CsvExporterJob.perform_later(to_email, from_date, to_date)
     redirect_to root_path, notice: "Your CSV is being generated, we will send an email to #{to_email} when it is ready to download"

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -36,8 +36,8 @@ class ResultsController < ApplicationController
 
   def export
     to_email  = params[:to_email].presence || Rails.application.secrets.notification_email
-    from_date = params[:from_date].to_s
-    to_date   = params[:to_date].to_s
+    from_date = params[:from_date]
+    to_date   = params[:to_date]
 
     CsvExporterJob.perform_later(to_email, from_date, to_date)
     redirect_to root_path, notice: "Your CSV is being generated, we will send an email to #{to_email} when it is ready to download"

--- a/app/jobs/csv_exporter_job.rb
+++ b/app/jobs/csv_exporter_job.rb
@@ -5,6 +5,6 @@ class CsvExporterJob < ApplicationJob
 
   def perform(to_email, from_date, to_date)
     file = CsvExporter.export_results(from_date, to_date)
-    NotificationMailer.csv_exported_email(file, to_email).deliver_now
+    NotificationMailer.csv_exported_email(file, to_email).deliver_later
   end
 end

--- a/app/jobs/csv_exporter_job.rb
+++ b/app/jobs/csv_exporter_job.rb
@@ -5,6 +5,6 @@ class CsvExporterJob < ApplicationJob
 
   def perform(to_email, from_date, to_date)
     file = CsvExporter.export_results(from_date, to_date)
-    NotificationMailer.csv_exported_email(file, to_email).deliver_later
+    NotificationMailer.csv_exported_email(file.to_s, to_email).deliver_now
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,6 +1,6 @@
 class NotificationMailer < ApplicationMailer
   def csv_exported_email(file, to_email)
-    @file = file
+    @file = Pathname.new(file)
     mail(to: to_email, subject: "Your CSV has finished exporting")
   end
 end


### PR DESCRIPTION
I have converted the file from a Pathname into a string and back into a Pathname due to there being an issue with the Pathname object being passed through the NotificationMailer.csv_exported_email method.