### PR TITLE
Set locale to english in csv export to prevent bug

### DIFF
--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -2,6 +2,7 @@ require 'csv'
 
 module CsvExporter
   def self.export_results(from_date, to_date)
+    I18n.locale = :en
     folder = Rails.root.join("public", "csv_exports")
     FileUtils.mkdir_p(folder)
     filepath = folder.join("csv_export_#{DateTime.now.to_i}.csv")


### PR DESCRIPTION
I discovered and fixed another issue. The locale is being picked up by the CSV export. This would output Spanish questions and answers to the generated CSV. I have now forced the locale to English in the csv export code.